### PR TITLE
feat: add prompt size limit config

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -372,6 +372,12 @@ export namespace Config {
         .string()
         .describe("Small model to use for tasks like title generation in the format of provider/model")
         .optional(),
+      prompt_size_limit: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Maximum prompt size in characters before sending to the model"),
       username: z
         .string()
         .optional()

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -632,6 +632,15 @@ export namespace Session {
         ]
       }),
     ).then((x) => x.flat())
+    const cfg = await Config.get()
+    const limit = cfg.prompt_size_limit
+    if (limit) {
+      const size = userParts.reduce((n, p) => {
+        if (p.type === "text") return n + p.text.length
+        return n
+      }, 0)
+      if (size > limit) throw new Error("prompt too large")
+    }
     await Plugin.trigger(
       "chat.message",
       {},

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -687,6 +687,7 @@ export namespace Session {
         )
       }, 0)
       if (size > limit) {
+        log.info("compact", { limit, size })
         state().autoCompacting.set(input.sessionID, true)
         await summarize({
           sessionID: input.sessionID,
@@ -705,6 +706,7 @@ export namespace Session {
       const tokens =
         previous.tokens.input + previous.tokens.cache.read + previous.tokens.cache.write + previous.tokens.output
       if (model.info.limit.context && tokens > Math.max((model.info.limit.context - outputLimit) * 0.9, 0)) {
+        log.info("compact", { tokens, limit: model.info.limit.context })
         state().autoCompacting.set(input.sessionID, true)
 
         await summarize({

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -632,15 +632,6 @@ export namespace Session {
         ]
       }),
     ).then((x) => x.flat())
-    const cfg = await Config.get()
-    const limit = cfg.prompt_size_limit
-    if (limit) {
-      const size = userParts.reduce((n, p) => {
-        if (p.type === "text") return n + p.text.length
-        return n
-      }, 0)
-      if (size > limit) throw new Error("prompt too large")
-    }
     await Plugin.trigger(
       "chat.message",
       {},
@@ -683,6 +674,28 @@ export namespace Session {
       return Provider.defaultModel()
     })().then((x) => Provider.getModel(x.providerID, x.modelID))
     let msgs = await messages(input.sessionID)
+    const cfg = await Config.get()
+    const limit = cfg.prompt_size_limit
+    if (limit) {
+      const size = msgs.reduce((n, m) => {
+        return (
+          n +
+          m.parts.reduce((p, part) => {
+            if (part.type === "text") return p + part.text.length
+            return p
+          }, 0)
+        )
+      }, 0)
+      if (size > limit) {
+        state().autoCompacting.set(input.sessionID, true)
+        await summarize({
+          sessionID: input.sessionID,
+          providerID: model.providerID,
+          modelID: model.info.id,
+        })
+        return prompt(input)
+      }
+    }
 
     const previous = msgs.filter((x) => x.info.role === "assistant").at(-1)?.info as MessageV2.Assistant
     const outputLimit = Math.min(model.info.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX


### PR DESCRIPTION
## Summary
- allow configuring maximum prompt size via `prompt_size_limit`
- enforce limit before sending prompt to model

## Testing
- `bun run typecheck` *(fails: Cannot find module '@opencode-ai/sdk', '@tsconfig/node22/tsconfig.json', etc.)*
- `bun test` *(fails: Cannot find package 'decimal.js', 'zod', 'zod-openapi/extend')*

------
https://chatgpt.com/codex/tasks/task_e_68c0827eb66c8330bc92cc76a2090fcf