### PR TITLE
fix: clamp output tokens to remaining context

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -106,10 +106,10 @@ export namespace ProviderTransform {
         const type = thinking["type"]
         const budgetTokens = thinking["budgetTokens"]
         if (type === "enabled" && typeof budgetTokens === "number" && budgetTokens > 0) {
-          return outputLimit - budgetTokens
+          return Math.max(outputLimit - budgetTokens, 1)
         }
       }
     }
-    return outputLimit
+    return Math.max(outputLimit, 1)
   }
 }

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -676,22 +676,26 @@ export namespace Session {
     let msgs = await messages(input.sessionID)
 
     const previous = msgs.filter((x) => x.info.role === "assistant").at(-1)?.info as MessageV2.Assistant
-    const outputLimit = Math.min(model.info.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX
+    const tokens =
+      previous?.tokens
+        ? previous.tokens.input + previous.tokens.cache.read + previous.tokens.cache.write + previous.tokens.output
+        : 0
+    const outputLimit = Math.min(
+      model.info.limit.output ?? OUTPUT_TOKEN_MAX,
+      OUTPUT_TOKEN_MAX,
+      model.info.limit.context ? Math.max(model.info.limit.context - tokens, 0) : OUTPUT_TOKEN_MAX,
+    )
 
     // auto summarize if too long
-    if (previous && previous.tokens) {
-      const tokens =
-        previous.tokens.input + previous.tokens.cache.read + previous.tokens.cache.write + previous.tokens.output
-      if (model.info.limit.context && tokens > Math.max((model.info.limit.context - outputLimit) * 0.9, 0)) {
-        state().autoCompacting.set(input.sessionID, true)
+    if (model.info.limit.context && tokens > Math.max((model.info.limit.context - outputLimit) * 0.9, 0)) {
+      state().autoCompacting.set(input.sessionID, true)
 
-        await summarize({
-          sessionID: input.sessionID,
-          providerID: model.providerID,
-          modelID: model.info.id,
-        })
-        return prompt(input)
-      }
+      await summarize({
+        sessionID: input.sessionID,
+        providerID: model.providerID,
+        modelID: model.info.id,
+      })
+      return prompt(input)
     }
     using abort = lock(input.sessionID)
 

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -676,10 +676,19 @@ export namespace Session {
     let msgs = await messages(input.sessionID)
 
     const previous = msgs.filter((x) => x.info.role === "assistant").at(-1)?.info as MessageV2.Assistant
-    const tokens =
+    const priorTokens =
       previous?.tokens
-        ? previous.tokens.input + previous.tokens.cache.read + previous.tokens.cache.write + previous.tokens.output
+        ?
+            previous.tokens.input +
+            previous.tokens.cache.read +
+            previous.tokens.cache.write +
+            previous.tokens.output
         : 0
+    const userTokens = userParts.reduce(
+      (sum, part) => (part.type === "text" ? sum + Math.ceil(part.text.length / 3) : sum),
+      0,
+    )
+    const tokens = priorTokens + userTokens
     const outputLimit = Math.min(
       model.info.limit.output ?? OUTPUT_TOKEN_MAX,
       OUTPUT_TOKEN_MAX,


### PR DESCRIPTION
## Summary
- clamp max output tokens to remaining context to avoid context length errors

## Testing
- `bun run typecheck`
- `bun test` *(fails: Cannot find module '@opencode-ai/sdk'; 8 fail, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_68c0943dda84833087553425802309a0