### PR TITLE
Compact session messages to respect context limits

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -366,6 +366,12 @@ export namespace Config {
         .optional()
         .describe("@deprecated Use 'share' field instead. Share newly created sessions automatically"),
       autoupdate: z.boolean().optional().describe("Automatically update to the latest version"),
+      max_output_tokens: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Maximum tokens allowed in model responses"),
       disabled_providers: z.array(z.string()).optional().describe("Disable providers that are loaded automatically"),
       model: z.string().describe("Model to use in the format of provider/model, eg anthropic/claude-2").optional(),
       small_model: z

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -99,17 +99,24 @@ export namespace ProviderTransform {
     return result
   }
 
-  export function maxOutputTokens(providerID: string, outputLimit: number, options: Record<string, any>): number {
+  export function maxOutputTokens(
+    providerID: string,
+    outputLimit: number,
+    options: Record<string, any>,
+    available?: number,
+  ): number {
+    const limit =
+      typeof available === "number" && available > 0 && available < outputLimit ? available : outputLimit
     if (providerID === "anthropic") {
       const thinking = options["thinking"]
       if (typeof thinking === "object" && thinking !== null) {
         const type = thinking["type"]
         const budgetTokens = thinking["budgetTokens"]
         if (type === "enabled" && typeof budgetTokens === "number" && budgetTokens > 0) {
-          return outputLimit - budgetTokens
+          return limit - budgetTokens
         }
       }
     }
-    return outputLimit
+    return limit
   }
 }

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -57,6 +57,7 @@ export namespace Session {
   const log = Log.create({ service: "session" })
 
   const OUTPUT_TOKEN_MAX = 32_000
+  const INPUT_TOKEN_BUFFER = 256
 
   const parentSessionTitlePrefix = "New session - "
   const childSessionTitlePrefix = "Child session - "
@@ -683,20 +684,31 @@ export namespace Session {
       return Provider.defaultModel()
     })().then((x) => Provider.getModel(x.providerID, x.modelID))
     let msgs = await messages(input.sessionID)
+    const lastSummary = msgs.findLast((msg) => msg.info.role === "assistant" && msg.info.summary === true)
+    if (lastSummary) msgs = msgs.filter((msg) => msg.info.id >= lastSummary.info.id)
 
-    const previous = msgs.filter((x) => x.info.role === "assistant").at(-1)?.info as MessageV2.Assistant
+    const system = await (async () => {
+      const items = [
+        ...SystemPrompt.header(model.providerID),
+        ...(() => {
+          if (input.system) return [input.system]
+          if (agent.prompt) return [agent.prompt]
+          return SystemPrompt.provider(model.modelID)
+        })(),
+        ...(await SystemPrompt.environment()),
+        ...(await SystemPrompt.custom()),
+      ]
+      const [first, ...rest] = items
+      return [first, rest.join("\n")]
+    })()
+    const sysTokens = system.reduce((n, x) => n + Math.ceil(x.length / 3), 0)
+    const ctx = model.info.limit.context
     const conf = await Config.state()
     const maxOut = conf.max_output_tokens ?? OUTPUT_TOKEN_MAX
     const outputLimit = Math.min(model.info.limit.output, maxOut) || maxOut
-    const prevTokens =
-      previous && previous.tokens
-        ? previous.tokens.input + previous.tokens.cache.read + previous.tokens.cache.write + previous.tokens.output
-        : 0
-    const newTokens = partTokens(userParts)
-    const totalTokens = prevTokens + newTokens
-    const ctx = model.info.limit.context
-    const threshold = ctx ? Math.max((ctx - outputLimit) * 0.9, 0) : 0
-    if (ctx && totalTokens > threshold) {
+    const baseTokens = sysTokens + msgs.reduce((n, m) => n + partTokens(m.parts), 0)
+    const threshold = ctx ? Math.max((ctx - outputLimit - INPUT_TOKEN_BUFFER) * 0.9, 0) : 0
+    if (ctx && baseTokens > threshold) {
       state().autoCompacting.set(input.sessionID, true)
       await summarize({
         sessionID: input.sessionID,
@@ -705,11 +717,8 @@ export namespace Session {
       })
       return prompt(input)
     }
-    const remain = ctx ? Math.max(ctx - totalTokens, 1) : outputLimit
     using abort = lock(input.sessionID)
 
-    const lastSummary = msgs.findLast((msg) => msg.info.role === "assistant" && msg.info.summary === true)
-    if (lastSummary) msgs = msgs.filter((msg) => msg.info.id >= lastSummary.info.id)
     const numRealUserMsgs = msgs.filter(
       (m) => m.info.role === "user" && !m.parts.every((p) => "synthetic" in p && p.synthetic),
     ).length
@@ -790,19 +799,8 @@ export namespace Session {
         synthetic: true,
       })
     }
-    let system = SystemPrompt.header(model.providerID)
-    system.push(
-      ...(() => {
-        if (input.system) return [input.system]
-        if (agent.prompt) return [agent.prompt]
-        return SystemPrompt.provider(model.modelID)
-      })(),
-    )
-    system.push(...(await SystemPrompt.environment()))
-    system.push(...(await SystemPrompt.custom()))
-    // max 2 system prompt messages for caching purposes
-    const [first, ...rest] = system
-    system = [first, rest.join("\n")]
+    const tokens = sysTokens + msgs.reduce((n, m) => n + partTokens(m.parts), 0)
+    const remain = ctx ? Math.max(ctx - tokens - INPUT_TOKEN_BUFFER, 1) : outputLimit
 
     const assistantMsg: MessageV2.Info = {
       id: Identifier.ascending("message"),

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -69,6 +69,15 @@ export namespace Session {
     return title.startsWith(parentSessionTitlePrefix)
   }
 
+  function partTokens(parts: MessageV2.Part[]) {
+    const count = (text: string) => Math.ceil(text.length / 3)
+    return parts.reduce((n, p) => {
+      if (p.type === "text") return n + count(p.text)
+      if (p.type === "file" && p.source?.text?.value) return n + count(p.source.text.value)
+      return n
+    }, 0)
+  }
+
   export const Info = z
     .object({
       id: Identifier.schema("session"),
@@ -676,23 +685,27 @@ export namespace Session {
     let msgs = await messages(input.sessionID)
 
     const previous = msgs.filter((x) => x.info.role === "assistant").at(-1)?.info as MessageV2.Assistant
-    const outputLimit = Math.min(model.info.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX
-
-    // auto summarize if too long
-    if (previous && previous.tokens) {
-      const tokens =
-        previous.tokens.input + previous.tokens.cache.read + previous.tokens.cache.write + previous.tokens.output
-      if (model.info.limit.context && tokens > Math.max((model.info.limit.context - outputLimit) * 0.9, 0)) {
-        state().autoCompacting.set(input.sessionID, true)
-
-        await summarize({
-          sessionID: input.sessionID,
-          providerID: model.providerID,
-          modelID: model.info.id,
-        })
-        return prompt(input)
-      }
+    const conf = await Config.state()
+    const maxOut = conf.max_output_tokens ?? OUTPUT_TOKEN_MAX
+    const outputLimit = Math.min(model.info.limit.output, maxOut) || maxOut
+    const prevTokens =
+      previous && previous.tokens
+        ? previous.tokens.input + previous.tokens.cache.read + previous.tokens.cache.write + previous.tokens.output
+        : 0
+    const newTokens = partTokens(userParts)
+    const totalTokens = prevTokens + newTokens
+    const ctx = model.info.limit.context
+    const threshold = ctx ? Math.max((ctx - outputLimit) * 0.9, 0) : 0
+    if (ctx && totalTokens > threshold) {
+      state().autoCompacting.set(input.sessionID, true)
+      await summarize({
+        sessionID: input.sessionID,
+        providerID: model.providerID,
+        modelID: model.info.id,
+      })
+      return prompt(input)
     }
+    const remain = ctx ? Math.max(ctx - totalTokens, 1) : outputLimit
     using abort = lock(input.sessionID)
 
     const lastSummary = msgs.findLast((msg) => msg.info.role === "assistant" && msg.info.summary === true)
@@ -1025,7 +1038,12 @@ export namespace Session {
           : undefined,
       maxRetries: 3,
       activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
-      maxOutputTokens: ProviderTransform.maxOutputTokens(model.providerID, outputLimit, params.options),
+      maxOutputTokens: ProviderTransform.maxOutputTokens(
+        model.providerID,
+        outputLimit,
+        params.options,
+        remain,
+      ),
       abortSignal: abort.signal,
       stopWhen: async ({ steps }) => {
         if (steps.length >= 1000) {


### PR DESCRIPTION
## Summary
- estimate tokens for new session messages and compact when near context limits
- cap requested output tokens by remaining context and new `max_output_tokens` config
- extend provider transform to consider available tokens

## Testing
- `bun run typecheck`
- `bun test` *(fails: Cannot find module '@opencode-ai/sdk'; z.object(...).openapi is not a function; plugin tool registration failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c09d8f14e4833090854042477aebcc