### PR TITLE
feat: add autocompact config option

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -365,6 +365,7 @@ export namespace Config {
         .boolean()
         .optional()
         .describe("@deprecated Use 'share' field instead. Share newly created sessions automatically"),
+      autocompact: z.boolean().optional().describe("Run compactor before every prompt is sent to the model"),
       autoupdate: z.boolean().optional().describe("Automatically update to the latest version"),
       disabled_providers: z.array(z.string()).optional().describe("Disable providers that are loaded automatically"),
       model: z.string().describe("Model to use in the format of provider/model, eg anthropic/claude-2").optional(),

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -674,6 +674,15 @@ export namespace Session {
       return Provider.defaultModel()
     })().then((x) => Provider.getModel(x.providerID, x.modelID))
     let msgs = await messages(input.sessionID)
+    const cfg = await Config.get()
+    if (cfg.autocompact && msgs.length) {
+      await summarize({
+        sessionID: input.sessionID,
+        providerID: model.providerID,
+        modelID: model.info.id,
+      })
+      msgs = await messages(input.sessionID)
+    }
 
     const previous = msgs.filter((x) => x.info.role === "assistant").at(-1)?.info as MessageV2.Assistant
     const outputLimit = Math.min(model.info.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -632,24 +632,20 @@ export namespace Session {
         ]
       }),
     ).then((x) => x.flat())
-    await Plugin.trigger(
-      "chat.message",
-      {},
-      {
-        message: userMsg,
-        parts: userParts,
-      },
-    )
-    await updateMessage(userMsg)
-    for (const part of userParts) {
-      await updatePart(part)
-    }
-
-    // mark session as updated
-    // used for session list sorting (indicates when session was most recently interacted with)
-    await update(input.sessionID, (_draft) => {})
-
     if (isLocked(input.sessionID)) {
+      await Plugin.trigger(
+        "chat.message",
+        {},
+        {
+          message: userMsg,
+          parts: userParts,
+        },
+      )
+      await updateMessage(userMsg)
+      for (const part of userParts) {
+        await updatePart(part)
+      }
+      await update(input.sessionID, (_draft) => {})
       return new Promise((resolve) => {
         const queue = state().queued.get(input.sessionID) ?? []
         queue.push({
@@ -673,16 +669,29 @@ export namespace Session {
       }
       return Provider.defaultModel()
     })().then((x) => Provider.getModel(x.providerID, x.modelID))
-    let msgs = await messages(input.sessionID)
     const cfg = await Config.get()
+    let msgs = await messages(input.sessionID)
     if (cfg.autocompact && msgs.length) {
       await summarize({
         sessionID: input.sessionID,
         providerID: model.providerID,
         modelID: model.info.id,
       })
-      msgs = await messages(input.sessionID)
     }
+    await Plugin.trigger(
+      "chat.message",
+      {},
+      {
+        message: userMsg,
+        parts: userParts,
+      },
+    )
+    await updateMessage(userMsg)
+    for (const part of userParts) {
+      await updatePart(part)
+    }
+    await update(input.sessionID, (_draft) => {})
+    msgs = await messages(input.sessionID)
 
     const previous = msgs.filter((x) => x.info.role === "assistant").at(-1)?.info as MessageV2.Assistant
     const outputLimit = Math.min(model.info.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX

--- a/packages/sdk/go/config.go
+++ b/packages/sdk/go/config.go
@@ -49,11 +49,13 @@ type Config struct {
 	Schema string `json:"$schema"`
 	// Agent configuration, see https://opencode.ai/docs/agent
 	Agent ConfigAgent `json:"agent"`
-	// @deprecated Use 'share' field instead. Share newly created sessions
-	// automatically
-	Autoshare bool `json:"autoshare"`
-	// Automatically update to the latest version
-	Autoupdate bool `json:"autoupdate"`
+        // @deprecated Use 'share' field instead. Share newly created sessions
+        // automatically
+        Autoshare bool `json:"autoshare"`
+        // Run compactor before every prompt is sent to the model
+        Autocompact bool `json:"autocompact"`
+        // Automatically update to the latest version
+        Autoupdate bool `json:"autoupdate"`
 	// Command configuration, see https://opencode.ai/docs/commands
 	Command map[string]ConfigCommand `json:"command"`
 	// Disable providers that are loaded automatically
@@ -96,12 +98,13 @@ type Config struct {
 
 // configJSON contains the JSON metadata for the struct [Config]
 type configJSON struct {
-	Schema            apijson.Field
-	Agent             apijson.Field
-	Autoshare         apijson.Field
-	Autoupdate        apijson.Field
-	Command           apijson.Field
-	DisabledProviders apijson.Field
+        Schema            apijson.Field
+        Agent             apijson.Field
+        Autoshare         apijson.Field
+        Autocompact       apijson.Field
+        Autoupdate        apijson.Field
+        Command           apijson.Field
+        DisabledProviders apijson.Field
 	Experimental      apijson.Field
 	Formatter         apijson.Field
 	Instructions      apijson.Field

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -572,6 +572,10 @@ export type Config = {
    */
   autoshare?: boolean
   /**
+   * Run compactor before every prompt is sent to the model
+   */
+   autocompact?: boolean
+   /**
    * Automatically update to the latest version
    */
   autoupdate?: boolean

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -18,6 +18,7 @@ opencode supports both **JSON** and **JSONC** (JSON with Comments) formats.
   "theme": "opencode",
   "model": "anthropic/claude-sonnet-4-20250514",
   "autoupdate": true,
+  "autocompact": true,
 }
 ```
 
@@ -201,6 +202,19 @@ opencode will automatically download any new updates when it starts up. You can 
 {
   "$schema": "https://opencode.ai/config.json",
   "autoupdate": false
+}
+```
+
+---
+
+### Autocompact
+
+Enable the `autocompact` option to compact the session before every prompt is sent to the model.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "autocompact": true
 }
 ```
 


### PR DESCRIPTION
## Summary
- add `autocompact` config field to trigger session compactor before each prompt
- document autocompact option in config docs
- extend SDK types for new autocompact config

## Testing
- `bun install`
- `bun run typecheck`
- `bun test` *(fails: Cannot find module '@opencode-ai/sdk'; TypeError: z.object(...).openapi is not a function; ENOENT: no such file or directory)*
- `bun run index.ts` *(fails: Module not found "index.ts")*


------
https://chatgpt.com/codex/tasks/task_e_68c145ba3c8483309b8e08da92544367